### PR TITLE
Multi-brand support (Audi, Škoda, SEAT, CUPRA) + auth/reauth fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install test dependencies
+        run: pip install -r requirements_test.txt
+
+      - name: Offline core tests (HA-independent)
+        run: python tests/test_offline.py
+
+      - name: HA integration tests
+        run: pytest tests/ -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,10 +9,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
-# Volkswagen EU Data Act — Home Assistant integration
+# VW Group EU Data Act — Home Assistant integration
 
 Periodically downloads your vehicle's "continuous data" from the Volkswagen
-EU Data Act portal (`eu-data-act.drivesomethinggreater.com`) and exposes it in
-Home Assistant.
+Group EU Data Act portal (`eu-data-act.drivesomethinggreater.com`) and exposes
+it in Home Assistant.
+
+**Supported brands:** Volkswagen · Audi · Škoda · SEAT · CUPRA
 
 ## Features
 
-- **Login with your VW credentials** and pick a VIN during setup (the portal is
-  queried for the vehicles on your account).
+- **Multi-brand support**: select your brand (Volkswagen, Audi, Škoda, SEAT or
+  CUPRA) during setup — each brand uses its own OIDC identity flow.
+- **Login with your brand credentials** and pick a VIN during setup (the portal
+  is queried for the vehicles on your account).
 - **Curated sensors** for the useful data points (battery SoC, target charge
   level, charge power, mileage, climate temperatures, charge state, doors
   locked, parking brake, …) — enabled by default with proper units and device
@@ -31,7 +35,8 @@ request** for your vehicle on the EU Data Act portal. The integration only
 request for you, and without an active request there will be nothing to fetch.
 
 1. Open <https://eu-data-act.drivesomethinggreater.com/> and **log in** with
-   your Volkswagen ID (the same email/password you'll use in Home Assistant).
+   your brand ID (Volkswagen ID / myAudi / myŠkoda / SEAT / CUPRA — the same
+   email/password you'll use in Home Assistant).
 2. Go to **Data clusters → Vehicle overview**.
 3. **Connect your car** to the site if it isn't already listed (follow the
    on-screen pairing/consent steps for your VIN).
@@ -39,7 +44,7 @@ request for you, and without an active request there will be nothing to fetch.
    configure a **continuous** data request with a **15-minute** frequency.
 5. Wait until the portal starts producing datasets (you'll see ZIP files appear
    in the vehicle's data delivery list, roughly every 15 minutes). The first
-   file can take a little while to show up.
+   file can take up to a few hours to show up.
 
 Once datasets are being generated, continue with the installation below.
 
@@ -59,14 +64,14 @@ Once datasets are being generated, continue with the installation below.
    - **Type / Category:** **Integration**
 
    Then click **Add**.
-4. Back in HACS, search for **Volkswagen EU Data Act**, open it, and click
+4. Back in HACS, search for **VW Group EU Data Act**, open it, and click
    **Download** (pick the latest version).
 5. **Restart Home Assistant** when prompted.
 6. Continue with [Add the integration](#add-the-integration) below.
 
 > Once the repository is published/approved you can instead use this one-click
 > link (replace with your published URL):
-> *HACS → Integrations → Explore & Download → "Volkswagen EU Data Act"*.
+> *HACS → Integrations → Explore & Download → "VW Group EU Data Act"*.
 
 ### Option B — Manual
 
@@ -77,9 +82,10 @@ Once datasets are being generated, continue with the installation below.
 
 ### Add the integration
 
-1. *Settings → Devices & Services → **Add Integration** → search "Volkswagen EU
+1. *Settings → Devices & Services → **Add Integration** → search "VW Group EU
    Data Act"*.
-2. Enter the **same VW email/password** you used on the portal, then select your
+2. **Select your brand** (Volkswagen, Audi, Škoda, SEAT or CUPRA).
+3. Enter the **same email/password** you used on the portal, then select your
    vehicle from the list.
 
 ## Notes & limitations
@@ -119,9 +125,10 @@ logger:
 
 > The portal's `/services/redirect/authentication` endpoint returns HTTP 500 for
 > non-browser clients, so the integration builds the OIDC `authorize` URL
-> directly. The login `state` defaults to country `si` / language `sl`; if your
-> account is in another locale and login misbehaves, adjust `DEFAULT_COUNTRY` /
-> `DEFAULT_LANGUAGE` in `custom_components/vw_eu_data_act/const.py`.
+> directly. If login fails, make sure you selected the **correct brand** in the
+> setup flow — each VW Group brand uses a different OIDC client ID and identity
+> flow. The login `state` is assembled as `de__en__{BRAND}` (country/language
+> defaults in `const.py`).
 
 ## Updating the data dictionary
 

--- a/README.md
+++ b/README.md
@@ -127,8 +127,7 @@ logger:
 > non-browser clients, so the integration builds the OIDC `authorize` URL
 > directly. If login fails, make sure you selected the **correct brand** in the
 > setup flow — each VW Group brand uses a different OIDC client ID and identity
-> flow. The login `state` is assembled as `de__en__{BRAND}` (country/language
-> defaults in `const.py`).
+> flow.
 
 ## Updating the data dictionary
 

--- a/custom_components/vw_eu_data_act/__init__.py
+++ b/custom_components/vw_eu_data_act/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .api import EudaApiClient
-from .const import CONF_EMAIL, CONF_PASSWORD, CONF_VIN, raw_unique_id
+from .const import CONF_BRAND, CONF_EMAIL, CONF_PASSWORD, CONF_VIN, DEFAULT_BRAND, raw_unique_id
 from .coordinator import EudaCoordinator
 from .data import load_dictionary
 
@@ -44,7 +44,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: EudaConfigEntry) -> bool
         # JSON file) so it doesn't block the loop during dataset parsing.
         await hass.async_add_executor_job(load_dictionary)
 
-        client = EudaApiClient(session, entry.data[CONF_EMAIL], entry.data[CONF_PASSWORD])
+        client = EudaApiClient(session, entry.data[CONF_EMAIL], entry.data[CONF_PASSWORD], entry.data.get(CONF_BRAND, DEFAULT_BRAND))
         coordinator = EudaCoordinator(hass, entry, client)
 
         await coordinator.async_config_entry_first_refresh()

--- a/custom_components/vw_eu_data_act/__init__.py
+++ b/custom_components/vw_eu_data_act/__init__.py
@@ -1,4 +1,4 @@
-"""The Volkswagen EU Data Act integration."""
+"""The VW Group EU Data Act integration."""
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/custom_components/vw_eu_data_act/api.py
+++ b/custom_components/vw_eu_data_act/api.py
@@ -19,10 +19,8 @@ from .const import (
     METADATA_PATH,
     NO_CONTENT_SUFFIX,
     OIDC_AUTHORIZE_URL,
-    OIDC_CLIENT_ID,
     OIDC_REDIRECT_URI,
     OIDC_SCOPE,
-    OIDC_STATE,
     RELATION_PATH,
     USER_AGENT,
     VEHICLES_PATH,
@@ -168,10 +166,11 @@ def _extract_vins(payload) -> list[dict]:
 class EudaApiClient:
     """Authenticated client for the EU Data Act portal."""
 
-    def __init__(self, session: aiohttp.ClientSession, email: str, password: str) -> None:
+    def __init__(self, session: aiohttp.ClientSession, email: str, password: str, brand: str = "volkswagen") -> None:
         self._session = session
         self._email = email
         self._password = password
+        self._brand = brand
         self._logged_in = False
 
     # -- low level ---------------------------------------------------------
@@ -203,7 +202,7 @@ class EudaApiClient:
         #    authorize URL ourselves because the portal's
         #    /services/redirect/authentication servlet returns HTTP 500 for
         #    non-browser clients.
-        authorize_url = self._build_authorize_url()
+        authorize_url = self._build_authorize_url(self._brand)
         _LOGGER.debug("login step1: authorize url = %s", authorize_url)
         async with await self._get(authorize_url) as resp:
             signin_url = str(resp.url)
@@ -281,13 +280,14 @@ class EudaApiClient:
             raise AuthError(f"Login did not complete (ended at {landing})")
 
     @staticmethod
-    def _build_authorize_url() -> str:
+    def _build_authorize_url(brand: str = "volkswagen") -> str:
         """Construct the OIDC authorize URL (bypasses the broken AEM servlet)."""
+        from .const import get_oidc_client_id, get_oidc_state
         params = {
-            "client_id": OIDC_CLIENT_ID,
+            "client_id": get_oidc_client_id(brand),
             "response_type": "code",
             "scope": OIDC_SCOPE,
-            "state": OIDC_STATE,
+            "state": get_oidc_state(brand),
             "redirect_uri": OIDC_REDIRECT_URI,
             "prompt": "login",
         }

--- a/custom_components/vw_eu_data_act/api.py
+++ b/custom_components/vw_eu_data_act/api.py
@@ -30,7 +30,16 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class ApiError(Exception):
-    """Generic API failure."""
+    """Generic API failure.
+
+    Carries the HTTP ``status`` when the failure came from an HTTP response, so
+    callers can branch on it (e.g. retry 5xx) without grepping the message
+    string. ``None`` for non-HTTP failures (connection errors, bad JSON, …).
+    """
+
+    def __init__(self, message: str, *, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
 
 
 class AuthError(ApiError):
@@ -304,7 +313,7 @@ class EudaApiClient:
                     await self.async_login()
                     return await self._get_json(url, headers=headers, _retry=False)
                 if resp.status >= 400:
-                    raise ApiError(f"GET {url} -> HTTP {resp.status}")
+                    raise ApiError(f"GET {url} -> HTTP {resp.status}", status=resp.status)
                 text = await resp.text()
         except aiohttp.ClientError as err:
             raise ApiError(f"Connection error for {url}: {err}") from err
@@ -371,10 +380,12 @@ class EudaApiClient:
                     await self.async_login()
                     async with await self._get(url, headers=headers) as resp2:
                         if resp2.status >= 400:
-                            raise ApiError(f"Download {name} -> HTTP {resp2.status}")
+                            raise ApiError(
+                                f"Download {name} -> HTTP {resp2.status}", status=resp2.status
+                            )
                         raw = await resp2.read()
                 elif resp.status >= 400:
-                    raise ApiError(f"Download {name} -> HTTP {resp.status}")
+                    raise ApiError(f"Download {name} -> HTTP {resp.status}", status=resp.status)
                 else:
                     raw = await resp.read()
         except aiohttp.ClientError as err:

--- a/custom_components/vw_eu_data_act/binary_sensor.py
+++ b/custom_components/vw_eu_data_act/binary_sensor.py
@@ -16,6 +16,7 @@ from .data import (
     CURATED_BINARY_FLAT,
     CuratedBinary,
     DataPoint,
+    decode_binary_state,
     detect_dataset_format,
     find_by_field,
 )
@@ -60,58 +61,8 @@ class EudaBinarySensor(EudaEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool | None:
         dp = find_by_field(self.coordinator.data or {}, self._curated.field_name)
-        result = None
-
-        if dp is not None:
-            val = dp.value
-
-            # Handle boolean values
-            if isinstance(val, bool):
-                result = (not val) if self._curated.invert else val
-
-            # Handle integer enum values (0/1=unavailable, 2/3=states)
-            elif isinstance(val, int):
-                # Special case: parking_brake uses simple 0/1 encoding
-                if "parking_brake" in self._curated.field_name:
-                    # 0=inactive (off), 1=active (on)
-                    result = val == 1
-                # Special case: parking_lights has 6 states (0-5)
-                elif "parking_lights" in self._curated.field_name:
-                    # 0=unsupported, 1=invalid -> unavailable
-                    if val in (0, 1):
-                        result = None
-                    # 2=off, 3=left, 4=right, 5=both
-                    else:
-                        result = val in (3, 4, 5)  # Any active state = ON
-                # 0=unsupported, 1=invalid -> unavailable (None)
-                elif val in (0, 1):
-                    result = None
-                # For open_state/window_state/sunroof: 2=open, 3=closed
-                # For locked_state: 2=locked, 3=unlocked
-                # For safe_state: 2=safe, 3=unsafe
-                elif val in (2, 3):
-                    # Determine if 2=on or 3=on based on field naming
-                    if (
-                        "open_state" in self._curated.field_name
-                        or "window_lifter" in self._curated.field_name
-                        or "state_sunroof" in self._curated.field_name
-                        or "state_of_hood" in self._curated.field_name
-                        or "state_service_hatch" in self._curated.field_name
-                        or "state_spoiler" in self._curated.field_name
-                    ):
-                        # 2=open (on), 3=closed (off)
-                        is_active = val == 2
-                    elif (
-                        "locked_state" in self._curated.field_name
-                        or "safe_state" in self._curated.field_name
-                    ):
-                        # 2=locked/safe, 3=unlocked/unsafe
-                        # With invert=True: val==2 (locked) -> is_active=True -> inverted -> on (locked)
-                        is_active = val == 2
-                    else:
-                        # Default: 2=off, 3=on
-                        is_active = val == 3
-
-                    result = (not is_active) if self._curated.invert else is_active
-
+        value = dp.value if dp is not None else None
+        result = decode_binary_state(
+            value, self._curated.encoding, self._curated.invert
+        )
         return self._sticky(result)

--- a/custom_components/vw_eu_data_act/binary_sensor.py
+++ b/custom_components/vw_eu_data_act/binary_sensor.py
@@ -17,6 +17,7 @@ from .data import (
     CuratedBinary,
     DataPoint,
     detect_dataset_format,
+    find_by_field,
 )
 from .entity import EudaEntity
 
@@ -43,16 +44,6 @@ async def async_setup_entry(
     )
 
 
-def _find_by_field(points: dict[str, DataPoint], field_name: str) -> DataPoint | None:
-    """Pick a single point for a (possibly duplicated) field name.
-
-    See sensor._find_by_field: the smallest UUID is chosen for a stable,
-    deterministic selection across refreshes.
-    """
-    matches = [dp for dp in points.values() if dp.field_name == field_name]
-    return min(matches, key=lambda dp: dp.key) if matches else None
-
-
 class EudaBinarySensor(EudaEntity, BinarySensorEntity):
     """A curated boolean sensor."""
 
@@ -68,7 +59,7 @@ class EudaBinarySensor(EudaEntity, BinarySensorEntity):
 
     @property
     def is_on(self) -> bool | None:
-        dp = _find_by_field(self.coordinator.data or {}, self._curated.field_name)
+        dp = find_by_field(self.coordinator.data or {}, self._curated.field_name)
         result = None
 
         if dp is not None:

--- a/custom_components/vw_eu_data_act/config_flow.py
+++ b/custom_components/vw_eu_data_act/config_flow.py
@@ -140,6 +140,7 @@ class EudaConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_reauth(
         self, entry_data: dict[str, Any]
     ) -> ConfigFlowResult:
+        self._brand = entry_data.get(CONF_BRAND, DEFAULT_BRAND)
         self._email = entry_data[CONF_EMAIL]
         return await self.async_step_reauth_confirm()
 

--- a/custom_components/vw_eu_data_act/config_flow.py
+++ b/custom_components/vw_eu_data_act/config_flow.py
@@ -16,11 +16,14 @@ from homeassistant.helpers.selector import (
 
 from .api import ApiError, AuthError, EudaApiClient
 from .const import (
+    BRAND_CHOICES,
+    CONF_BRAND,
     CONF_EMAIL,
     CONF_IDENTIFIER,
     CONF_NICKNAME,
     CONF_PASSWORD,
     CONF_VIN,
+    DEFAULT_BRAND,
     DOMAIN,
 )
 
@@ -33,6 +36,7 @@ class EudaConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
 
     def __init__(self) -> None:
+        self._brand: str = DEFAULT_BRAND
         self._email: str | None = None
         self._password: str | None = None
         self._vehicles: list[dict] = []
@@ -40,6 +44,24 @@ class EudaConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Step 1: Select brand."""
+        if user_input is not None:
+            self._brand = user_input[CONF_BRAND]
+            return await self.async_step_credentials()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_BRAND, default=DEFAULT_BRAND): vol.In(BRAND_CHOICES),
+                }
+            ),
+        )
+
+    async def async_step_credentials(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Step 2: Enter email and password."""
         errors: dict[str, str] = {}
         if user_input is not None:
             self._email = user_input[CONF_EMAIL]
@@ -53,7 +75,7 @@ class EudaConfigFlow(ConfigFlow, domain=DOMAIN):
                 return await self.async_step_vehicle()
 
         return self.async_show_form(
-            step_id="user",
+            step_id="credentials",
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_EMAIL): str,
@@ -87,6 +109,7 @@ class EudaConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(
                     title=title,
                     data={
+                        CONF_BRAND: self._brand,
                         CONF_EMAIL: self._email,
                         CONF_PASSWORD: self._password,
                         CONF_VIN: vin,
@@ -150,7 +173,7 @@ class EudaConfigFlow(ConfigFlow, domain=DOMAIN):
     async def _async_try_login(self) -> str | None:
         """Attempt login + vehicle discovery; return an error key or None."""
         session = aiohttp.ClientSession(cookie_jar=aiohttp.CookieJar())
-        client = EudaApiClient(session, self._email, self._password)
+        client = EudaApiClient(session, self._email, self._password, self._brand)
         try:
             await client.async_login()
             self._vehicles = await client.async_list_vehicles()
@@ -167,7 +190,7 @@ class EudaConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def _async_fetch_identifier(self, vin: str) -> tuple[str, str | None]:
         session = aiohttp.ClientSession(cookie_jar=aiohttp.CookieJar())
-        client = EudaApiClient(session, self._email, self._password)
+        client = EudaApiClient(session, self._email, self._password, self._brand)
         try:
             await client.async_login()
             meta = await client.async_get_metadata(vin)

--- a/custom_components/vw_eu_data_act/const.py
+++ b/custom_components/vw_eu_data_act/const.py
@@ -19,21 +19,74 @@ def raw_unique_id(vin: str, key: str) -> str:
 BASE_URL = "https://eu-data-act.drivesomethinggreater.com"
 IDENTITY_BASE = "https://identity.vwgroup.io"
 
-# Brand is part of the OIDC state; VW passenger cars by default.
-BRAND = "VOLKSWAGEN_PASSENGER_CARS"
 CALLBACK_LOGIN_PATH = "/services/callbacklogin"
 
 # OIDC: we build the authorize URL directly instead of using the portal's
 # /services/redirect/authentication servlet, which returns HTTP 500 for
 # non-browser clients (it depends on AEM browser session state).
 OIDC_AUTHORIZE_URL = IDENTITY_BASE + "/oidc/v1/authorize"
-OIDC_CLIENT_ID = "9b58543e-1c15-4193-91d5-8a14145bebb0@apps_vw-dilab_com"
 OIDC_SCOPE = "openid cars profile"
 OIDC_REDIRECT_URI = BASE_URL + "/login"
+
+# --- Multi-brand configuration --------------------------------------------
+# Each brand has its own client_id and state string for the OIDC flow.
+# Client IDs extracted from the evcc project (vehicle/vw/eudataact/types.go).
+
+BRANDS: dict[str, dict[str, str]] = {
+    "volkswagen": {
+        "display_name": "Volkswagen",
+        "client_id": "9b58543e-1c15-4193-91d5-8a14145bebb0@apps_vw-dilab_com",
+        "state": "VOLKSWAGEN_PASSENGER_CARS",
+    },
+    "audi": {
+        "display_name": "Audi",
+        "client_id": "cc29b87a-5e9a-4362-aecf-5adea6b01bbb@apps_vw-dilab_com",
+        "state": "AUDI",
+    },
+    "skoda": {
+        "display_name": "Škoda",
+        "client_id": "3ea88bf9-1d4e-4a68-b3ad-4098c1f1d246@apps_vw-dilab_com",
+        "state": "SKODA",
+    },
+    "seat": {
+        "display_name": "SEAT",
+        "client_id": "f85e5b69-e3b2-43aa-9c0d-1b7d0e0b576f@apps_vw-dilab_com",
+        "state": "SEAT",
+    },
+    "cupra": {
+        "display_name": "CUPRA",
+        "client_id": "f85e5b69-e3b2-43aa-9c0d-1b7d0e0b576f@apps_vw-dilab_com",
+        "state": "CUPRA",
+    },
+}
+
+BRAND_CHOICES: dict[str, str] = {k: v["display_name"] for k, v in BRANDS.items()}
+
+# Default brand for backward compatibility with existing config entries
+DEFAULT_BRAND = "volkswagen"
+
 # state encodes country__language__brand (echoed back to the portal callback).
-DEFAULT_COUNTRY = "si"
-DEFAULT_LANGUAGE = "sl"
-OIDC_STATE = f"{DEFAULT_COUNTRY}__{DEFAULT_LANGUAGE}__{BRAND}"
+DEFAULT_COUNTRY = "de"
+DEFAULT_LANGUAGE = "en"
+
+# Config entry key for brand selection
+CONF_BRAND = "brand"
+
+
+def get_oidc_client_id(brand: str = DEFAULT_BRAND) -> str:
+    """Return the OIDC client_id for the given brand."""
+    return BRANDS.get(brand, BRANDS[DEFAULT_BRAND])["client_id"]
+
+
+def get_oidc_state(brand: str = DEFAULT_BRAND) -> str:
+    """Return the OIDC state for the given brand."""
+    brand_state = BRANDS.get(brand, BRANDS[DEFAULT_BRAND])["state"]
+    return f"{DEFAULT_COUNTRY}__{DEFAULT_LANGUAGE}__{brand_state}"
+
+
+# Legacy constants for backward compatibility (default to VW)
+OIDC_CLIENT_ID = BRANDS[DEFAULT_BRAND]["client_id"]
+OIDC_STATE = get_oidc_state(DEFAULT_BRAND)
 
 # proxy_api paths (relative to BASE_URL)
 VEHICLES_PATH = "/proxy_api/consent/me/vehicles"

--- a/custom_components/vw_eu_data_act/const.py
+++ b/custom_components/vw_eu_data_act/const.py
@@ -48,6 +48,9 @@ BRANDS: dict[str, dict[str, str]] = {
         "client_id": "3ea88bf9-1d4e-4a68-b3ad-4098c1f1d246@apps_vw-dilab_com",
         "state": "SKODA",
     },
+    # SEAT and CUPRA intentionally share one client_id (CUPRA runs on SEAT's
+    # identity backend); they differ only by the state suffix. Matches evcc
+    # (vehicle/vw/eudataact/types.go) — not a copy-paste slip.
     "seat": {
         "display_name": "SEAT",
         "client_id": "f85e5b69-e3b2-43aa-9c0d-1b7d0e0b576f@apps_vw-dilab_com",

--- a/custom_components/vw_eu_data_act/coordinator.py
+++ b/custom_components/vw_eu_data_act/coordinator.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
@@ -115,6 +116,8 @@ class EudaCoordinator(DataUpdateCoordinator[dict[str, DataPoint]]):
                     self._is_initial_setup = False
                     last_error = None
                     break  # Success!
+                except AuthError as err:
+                    raise ConfigEntryAuthFailed(str(err)) from err
                 except ApiError as err:
                     last_error = err
                     is_server_error = any(
@@ -222,8 +225,7 @@ class EudaCoordinator(DataUpdateCoordinator[dict[str, DataPoint]]):
                     return listing
 
                 except AuthError as err:
-                    self.update_interval = RETRY_INTERVAL
-                    raise UpdateFailed(f"Authentication failed: {err}") from err
+                    raise ConfigEntryAuthFailed(str(err)) from err
 
                 except ApiError as err:
                     last_error = err

--- a/custom_components/vw_eu_data_act/coordinator.py
+++ b/custom_components/vw_eu_data_act/coordinator.py
@@ -27,6 +27,14 @@ from .data import Dataset, DataPoint
 
 _LOGGER = logging.getLogger(__name__)
 
+# Transient upstream errors worth retrying / keeping previous data for.
+_SERVER_ERROR_CODES = frozenset({500, 502, 503, 504})
+
+
+def _is_server_error(err: Exception) -> bool:
+    """True for transient upstream 5xx failures (carried on ApiError.status)."""
+    return getattr(err, "status", None) in _SERVER_ERROR_CODES
+
 
 def _filename_timestamp(name: str) -> datetime | None:
     """Parse a YYYYMMDDhhmmss segment from a dataset filename.
@@ -120,10 +128,7 @@ class EudaCoordinator(DataUpdateCoordinator[dict[str, DataPoint]]):
                     raise ConfigEntryAuthFailed(str(err)) from err
                 except ApiError as err:
                     last_error = err
-                    is_server_error = any(
-                        code in str(err)
-                        for code in ["HTTP 500", "HTTP 502", "HTTP 503", "HTTP 504"]
-                    )
+                    is_server_error = _is_server_error(err)
 
                     if is_server_error and attempt < max_retries - 1:
                         _LOGGER.debug(
@@ -153,10 +158,7 @@ class EudaCoordinator(DataUpdateCoordinator[dict[str, DataPoint]]):
             if last_error is None:
                 break
 
-            if last_error and not any(
-                code in str(last_error)
-                for code in ["HTTP 500", "HTTP 502", "HTTP 503", "HTTP 504"]
-            ):
+            if last_error and not _is_server_error(last_error):
                 break
 
         # If all downloads failed
@@ -229,10 +231,7 @@ class EudaCoordinator(DataUpdateCoordinator[dict[str, DataPoint]]):
 
                 except ApiError as err:
                     last_error = err
-                    is_server_error = any(
-                        code in str(err)
-                        for code in ["HTTP 500", "HTTP 502", "HTTP 503", "HTTP 504"]
-                    )
+                    is_server_error = _is_server_error(err)
 
                     # Retry server errors with delay
                     if is_server_error and attempt < max_retries - 1:
@@ -256,7 +255,7 @@ class EudaCoordinator(DataUpdateCoordinator[dict[str, DataPoint]]):
                 self.update_interval = RETRY_INTERVAL
 
                 # HTTP 400 special case
-                if "HTTP 400" in str(last_error):
+                if getattr(last_error, "status", None) == 400:
                     raise UpdateFailed(
                         "Data delivery not ready yet (HTTP 400). If you just enabled "
                         "the continuous data request on the portal, it can take a few "
@@ -264,11 +263,7 @@ class EudaCoordinator(DataUpdateCoordinator[dict[str, DataPoint]]):
                     ) from last_error
 
                 # Server errors with existing data - return empty to keep old data
-                is_server_error = any(
-                    code in str(last_error)
-                    for code in ["HTTP 500", "HTTP 502", "HTTP 503", "HTTP 504"]
-                )
-                if is_server_error and self.data:
+                if _is_server_error(last_error) and self.data:
                     _LOGGER.error(
                         "Failed to list datasets after %d attempts: %s. Keeping previous data.",
                         max_retries,

--- a/custom_components/vw_eu_data_act/coordinator.py
+++ b/custom_components/vw_eu_data_act/coordinator.py
@@ -71,6 +71,9 @@ class EudaCoordinator(DataUpdateCoordinator[dict[str, DataPoint]]):
         super().__init__(
             hass,
             _LOGGER,
+            # Pass the entry explicitly; relying on the ContextVar is deprecated
+            # and breaks in HA 2026.8.
+            config_entry=entry,
             name=f"{DOMAIN} {entry.data[CONF_VIN]}",
             update_interval=RETRY_INTERVAL,
         )

--- a/custom_components/vw_eu_data_act/data.py
+++ b/custom_components/vw_eu_data_act/data.py
@@ -383,6 +383,49 @@ class CuratedBinary:
     device_class: str | None = None
     invert: bool = False  # is_on = (value is False) when True
     icon: str | None = None
+    # How the field's integer value maps to on/off (see decode_binary_state):
+    # "open"   - 2=active, 3=inactive, 0/1=unknown  (doors, windows, locks, …)
+    # "onoff"  - 0=off, 1=on                         (parking_brake)
+    # "lights" - 2=off, 3/4/5=on, 0/1=unknown        (parking_lights)
+    encoding: str = "open"
+
+
+def decode_binary_state(
+    value, encoding: str = "open", invert: bool = False
+) -> bool | None:
+    """Decode a curated binary field's raw value into on / off / unknown.
+
+    Vehicle status fields encode their boolean in several ways, selected per
+    sensor via ``CuratedBinary.encoding`` rather than guessed from the field
+    name at runtime:
+
+      "open"   - 0/1 = unsupported/invalid (-> unknown); 2 = active (open /
+                 locked / safe / …), 3 = inactive. The dominant encoding for
+                 doors, windows, sunroofs and lock/safe states.
+      "onoff"  - 0 = off, 1 = on (e.g. parking_brake).
+      "lights" - 0/1 = unsupported/invalid; 2 = off; 3/4/5 = on (parking_lights).
+
+    Plain booleans are returned as-is regardless of ``encoding``. ``invert``
+    flips a decoded True/False (a "lock" sensor reads on when *un*locked); it
+    never turns a known state into unknown. Returns None when the value is
+    missing or carries an unsupported/invalid sentinel.
+    """
+    if isinstance(value, bool):
+        result: bool | None = value
+    elif isinstance(value, int):
+        if encoding == "onoff":
+            result = value == 1
+        elif encoding == "lights":
+            result = None if value in (0, 1) else value in (3, 4, 5)
+        elif value in (0, 1):
+            result = None  # unsupported / invalid sentinel
+        else:  # "open": 2 = active, 3 = inactive
+            result = value == 2
+    else:
+        result = None
+    if result is None:
+        return None
+    return (not result) if invert else result
 
 
 # ---------------------------------------------------------------------------
@@ -546,7 +589,13 @@ CURATED_BINARY_DOTTED: tuple[CuratedBinary, ...] = (
     CuratedBinary("locked", "Vehicle locked", "lock", invert=True, icon="mdi:car-key"),
     # ID.x datasets carry a flat-named parking_brake field even though most of
     # their fields are dotted, so it belongs in the dotted group too.
-    CuratedBinary("parking_brake", "Parking brake", None, icon="mdi:car-brake-parking"),
+    CuratedBinary(
+        "parking_brake",
+        "Parking brake",
+        None,
+        icon="mdi:car-brake-parking",
+        encoding="onoff",
+    ),
 )
 
 # ---------------------------------------------------------------------------
@@ -1084,9 +1133,19 @@ CURATED_BINARY_FLAT: tuple[CuratedBinary, ...] = (
         icon="mdi:car-convertible",
     ),
     # === Other Binary States ===
-    CuratedBinary("parking_brake", "Parking brake", None, icon="mdi:car-brake-parking"),
     CuratedBinary(
-        "parking_lights", "Parking lights", "light", icon="mdi:car-parking-lights"
+        "parking_brake",
+        "Parking brake",
+        None,
+        icon="mdi:car-brake-parking",
+        encoding="onoff",
+    ),
+    CuratedBinary(
+        "parking_lights",
+        "Parking lights",
+        "light",
+        icon="mdi:car-parking-lights",
+        encoding="lights",
     ),
     CuratedBinary("state_of_hood", "Hood state", None, icon="mdi:car"),
     CuratedBinary("state_service_hatch", "Service hatch", None, icon="mdi:gas-station"),

--- a/custom_components/vw_eu_data_act/data.py
+++ b/custom_components/vw_eu_data_act/data.py
@@ -227,18 +227,25 @@ class Dataset:
         )
 
     def by_field(self, field_name: str) -> DataPoint | None:
-        """Return a single data point for a (possibly duplicated) field name.
+        """Return a single data point for a (possibly duplicated) field name."""
+        return find_by_field(self.points, field_name)
 
-        The portal merges several report snapshots into one flat array with no
-        ordering guarantee and no way to tell which value is "live", so a field
-        like ``charging_state_report.current_charge_state`` can appear several
-        times under different UUIDs with conflicting values. We pick the entry
-        with the smallest ``key`` (UUID): an arbitrary but *stable* choice, so a
-        curated sensor consistently tracks the same data point across refreshes
-        instead of flip-flopping when the portal reshuffles the array.
-        """
-        matches = [dp for dp in self.points.values() if dp.field_name == field_name]
-        return min(matches, key=lambda dp: dp.key) if matches else None
+
+def find_by_field(
+    points: dict[str, "DataPoint"], field_name: str
+) -> "DataPoint | None":
+    """Pick a single data point for a (possibly duplicated) field name.
+
+    The portal merges several report snapshots into one flat array with no
+    ordering guarantee and no way to tell which value is "live", so a field
+    like ``charging_state_report.current_charge_state`` can appear several
+    times under different UUIDs with conflicting values. We pick the entry with
+    the smallest ``key`` (UUID): an arbitrary but *stable* choice, so a curated
+    sensor consistently tracks the same data point across refreshes instead of
+    flip-flopping when the portal reshuffles the array.
+    """
+    matches = [dp for dp in points.values() if dp.field_name == field_name]
+    return min(matches, key=lambda dp: dp.key) if matches else None
 
 
 def _parse_timestamp(raw: str) -> datetime | None:

--- a/custom_components/vw_eu_data_act/entity.py
+++ b/custom_components/vw_eu_data_act/entity.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import CONF_NICKNAME, DOMAIN
+from .const import BRANDS, CONF_BRAND, CONF_NICKNAME, DEFAULT_BRAND, DOMAIN
 from .coordinator import EudaCoordinator
 from .data import sticky
 
@@ -19,10 +19,12 @@ class EudaEntity(CoordinatorEntity[EudaCoordinator]):
         self._last_value = None
         vin = coordinator.vin
         name = coordinator.entry.data.get(CONF_NICKNAME) or vin
+        brand_key = coordinator.entry.data.get(CONF_BRAND, DEFAULT_BRAND)
+        brand_info = BRANDS.get(brand_key, BRANDS[DEFAULT_BRAND])
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, vin)},
             name=name,
-            manufacturer="Volkswagen",
+            manufacturer=brand_info["display_name"],
             model="EU Data Act vehicle",
             serial_number=vin,
         )

--- a/custom_components/vw_eu_data_act/manifest.json
+++ b/custom_components/vw_eu_data_act/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "vw_eu_data_act",
-  "name": "Volkswagen EU Data Act",
-  "version": "0.1.8",
+  "name": "VW Group EU Data Act",
+  "version": "0.2.0",
   "codeowners": [],
   "config_flow": true,
   "dependencies": [],

--- a/custom_components/vw_eu_data_act/sensor.py
+++ b/custom_components/vw_eu_data_act/sensor.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -28,6 +30,52 @@ from .data import (
     resolve_distance_unit,
 )
 from .entity import EudaEntity
+
+
+def _shorten_enum_value(dp: DataPoint, value) -> object:
+    """Shorten verbose VW enum labels for display only.
+
+    Keeps DataPoint.raw_value unchanged. Removes enum prefixes that are
+    repeated in the field name, e.g. for ``charging_state_report.current_charge_state``
+    the value ``CHARGE_STATE_CHARGING_HV_BATTERY`` becomes ``CHARGING_HV_BATTERY``.
+    """
+    if dp is None or not isinstance(value, str):
+        return value
+
+    if not re.fullmatch(r"[A-Z0-9_]+", value):
+        return value
+
+    def normalize(text: str) -> str:
+        return re.sub(r"[^A-Za-z0-9]+", "_", text).strip("_").upper()
+
+    candidates: list[str] = []
+
+    def add_candidate(text: str) -> None:
+        normalized = normalize(text)
+        if normalized and normalized not in candidates:
+            candidates.append(normalized)
+
+    field_name = dp.field_name or ""
+    add_candidate(field_name)
+    for part in field_name.split("."):
+        add_candidate(part)
+
+    normalized_field = normalize(field_name)
+    for removable in ("SETTINGS_", "STATUS_", "CHARGING_STATE_REPORT_"):
+        if normalized_field.startswith(removable):
+            add_candidate(normalized_field.removeprefix(removable))
+
+    for candidate in list(candidates):
+        tokens = candidate.split("_")
+        for i in range(1, len(tokens)):
+            add_candidate("_".join(tokens[i:]))
+
+    for prefix in sorted(candidates, key=len, reverse=True):
+        full_prefix = f"{prefix}_"
+        if value.startswith(full_prefix) and len(value) > len(full_prefix):
+            return value[len(full_prefix):]
+
+    return value
 
 
 async def async_setup_entry(
@@ -127,7 +175,7 @@ class EudaCuratedSensor(EudaEntity, SensorEntity):
                 transformed = fuel_consumption_l_per_1000km_to_l_per_100km(raw_value)
                 return self._sticky(transformed)
 
-        return self._sticky(raw_value)
+        return self._sticky(_shorten_enum_value(dp, raw_value))
 
     @property
     def native_unit_of_measurement(self) -> str | None:
@@ -166,7 +214,7 @@ class EudaRawSensor(EudaEntity, SensorEntity):
     @property
     def native_value(self):
         dp = (self.coordinator.data or {}).get(self._key)
-        return self._sticky(dp.value if dp else None)
+        return self._sticky(_shorten_enum_value(dp, dp.value) if dp else None)
 
     @property
     def extra_state_attributes(self) -> dict:

--- a/custom_components/vw_eu_data_act/sensor.py
+++ b/custom_components/vw_eu_data_act/sensor.py
@@ -101,24 +101,6 @@ class EudaCuratedSensor(EudaEntity, SensorEntity):
         if curated.suggested_display_precision is not None:
             self._attr_suggested_display_precision = curated.suggested_display_precision
 
-    def _apply_transform(self, value):
-        """Apply configured transform to the raw value."""
-        if value is None or not self._curated.transform:
-            return value
-
-        transform = self._curated.transform
-
-        if transform == "duration_s":
-            # Already handled by parse_duration_seconds in parse_value
-            return value
-
-        if transform == "decikelvin_to_celsius":
-            from .data import decikelvin_to_celsius
-
-            return decikelvin_to_celsius(str(value))
-
-        return value
-
     @property
     def native_value(self):
         # Special handling for timestamp fields (both "mileage.timestamp" and "mileage.value.timestamp")

--- a/custom_components/vw_eu_data_act/sensor.py
+++ b/custom_components/vw_eu_data_act/sensor.py
@@ -23,6 +23,7 @@ from .data import (
     CuratedSensor,
     DataPoint,
     detect_dataset_format,
+    find_by_field,
     friendly_name,
     resolve_distance_unit,
 )
@@ -72,18 +73,6 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-def _find_by_field(points: dict[str, DataPoint], field_name: str) -> DataPoint | None:
-    """Pick a single point for a (possibly duplicated) field name.
-
-    The portal's flat array is unordered and a field can appear multiple times
-    under different UUIDs with conflicting values, with no way to tell which is
-    "live". Select the smallest UUID: arbitrary but stable, so the sensor tracks
-    the same data point across refreshes instead of flip-flopping on reshuffle.
-    """
-    matches = [dp for dp in points.values() if dp.field_name == field_name]
-    return min(matches, key=lambda dp: dp.key) if matches else None
-
-
 class EudaCuratedSensor(EudaEntity, SensorEntity):
     """A curated, well-typed sensor (enabled by default)."""
 
@@ -106,12 +95,12 @@ class EudaCuratedSensor(EudaEntity, SensorEntity):
         # Special handling for timestamp fields (both "mileage.timestamp" and "mileage.value.timestamp")
         if ".timestamp" in self._curated.field_name:
             base_field = self._curated.field_name.replace(".timestamp", "")
-            dp = _find_by_field(self.coordinator.data or {}, base_field)
+            dp = find_by_field(self.coordinator.data or {}, base_field)
             if dp and dp.timestamp:
                 return self._sticky(dp.timestamp)
             return self._sticky(None)
 
-        dp = _find_by_field(self.coordinator.data or {}, self._curated.field_name)
+        dp = find_by_field(self.coordinator.data or {}, self._curated.field_name)
 
         if not dp:
             return self._sticky(None)
@@ -147,7 +136,7 @@ class EudaCuratedSensor(EudaEntity, SensorEntity):
         # otherwise use the static curated unit.
         cur = self._curated
         if cur.unit_field:
-            dp = _find_by_field(self.coordinator.data or {}, cur.unit_field)
+            dp = find_by_field(self.coordinator.data or {}, cur.unit_field)
             if dp is not None:
                 resolver = UNIT_RESOLVERS.get(cur.unit_resolver, resolve_distance_unit)
                 resolved = resolver(dp.value)

--- a/custom_components/vw_eu_data_act/strings.json
+++ b/custom_components/vw_eu_data_act/strings.json
@@ -2,8 +2,15 @@
   "config": {
     "step": {
       "user": {
-        "title": "Volkswagen EU Data Act",
-        "description": "Sign in with your Volkswagen ID credentials used on the EU Data Act portal.",
+        "title": "VW Group EU Data Act",
+        "description": "Select your vehicle brand. All VW Group brands are supported through the EU Data Act portal.",
+        "data": {
+          "brand": "Brand"
+        }
+      },
+      "credentials": {
+        "title": "Sign in",
+        "description": "Enter your VW-ID credentials (same as on eu-data-act.drivesomethinggreater.com).",
         "data": {
           "email": "Email",
           "password": "Password"
@@ -24,9 +31,9 @@
       }
     },
     "error": {
-      "invalid_auth": "Invalid email or password.",
+      "invalid_auth": "Invalid email or password. If using Škoda/Audi/SEAT/CUPRA, make sure to select the correct brand.",
       "cannot_connect": "Could not connect to the EU Data Act portal.",
-      "no_vehicles": "No vehicles were found for this account.",
+      "no_vehicles": "No vehicles were found for this account. Make sure you have linked your vehicle on eu-data-act.drivesomethinggreater.com first.",
       "unknown": "An unexpected error occurred."
     },
     "abort": {

--- a/custom_components/vw_eu_data_act/translations/de.json
+++ b/custom_components/vw_eu_data_act/translations/de.json
@@ -1,0 +1,45 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "VW Group EU Data Act",
+        "description": "Wählen Sie Ihre Fahrzeugmarke. Alle Marken des VW-Konzerns werden über das EU Data Act Portal unterstützt.",
+        "data": {
+          "brand": "Marke"
+        }
+      },
+      "credentials": {
+        "title": "Anmeldung",
+        "description": "Geben Sie Ihre VW-ID Zugangsdaten ein (dieselben wie auf eu-data-act.drivesomethinggreater.com).",
+        "data": {
+          "email": "E-Mail",
+          "password": "Passwort"
+        }
+      },
+      "vehicle": {
+        "title": "Fahrzeug auswählen",
+        "data": {
+          "vin": "Fahrzeug"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Erneut anmelden",
+        "description": "Geben Sie das Passwort für {email} ein.",
+        "data": {
+          "password": "Passwort"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "E-Mail oder Passwort falsch. Bei Škoda/Audi/SEAT/CUPRA stellen Sie sicher, dass die richtige Marke ausgewählt ist.",
+      "cannot_connect": "Verbindung zum EU Data Act Portal nicht möglich.",
+      "no_vehicles": "Keine Fahrzeuge für dieses Konto gefunden. Stellen Sie sicher, dass Ihr Fahrzeug auf eu-data-act.drivesomethinggreater.com verknüpft ist.",
+      "unknown": "Ein unerwarteter Fehler ist aufgetreten."
+    },
+    "abort": {
+      "already_configured": "Dieses Fahrzeug ist bereits konfiguriert.",
+      "auth": "Authentifizierung fehlgeschlagen; bitte die Integration erneut hinzufügen.",
+      "reauth_successful": "Erneute Authentifizierung erfolgreich."
+    }
+  }
+}

--- a/custom_components/vw_eu_data_act/translations/en.json
+++ b/custom_components/vw_eu_data_act/translations/en.json
@@ -2,8 +2,15 @@
   "config": {
     "step": {
       "user": {
-        "title": "Volkswagen EU Data Act",
-        "description": "Sign in with your Volkswagen ID credentials used on the EU Data Act portal.",
+        "title": "VW Group EU Data Act",
+        "description": "Select your vehicle brand. All VW Group brands are supported through the EU Data Act portal.",
+        "data": {
+          "brand": "Brand"
+        }
+      },
+      "credentials": {
+        "title": "Sign in",
+        "description": "Enter your VW-ID credentials (same as on eu-data-act.drivesomethinggreater.com).",
         "data": {
           "email": "Email",
           "password": "Password"
@@ -24,9 +31,9 @@
       }
     },
     "error": {
-      "invalid_auth": "Invalid email or password.",
+      "invalid_auth": "Invalid email or password. If using Škoda/Audi/SEAT/CUPRA, make sure to select the correct brand.",
       "cannot_connect": "Could not connect to the EU Data Act portal.",
-      "no_vehicles": "No vehicles were found for this account.",
+      "no_vehicles": "No vehicles were found for this account. Make sure you have linked your vehicle on eu-data-act.drivesomethinggreater.com first.",
       "unknown": "An unexpected error occurred."
     },
     "abort": {

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+# The HA test harness (pytest-homeassistant-custom-component) provides async
+# fixtures like `hass`; pytest-asyncio must run in auto mode to handle them
+# (HA core sets the same in its pyproject.toml).
+asyncio_mode = auto
+testpaths = tests

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,3 @@
+# Test dependencies. pytest-homeassistant-custom-component pulls in a matching
+# Home Assistant core and pytest, so this single pin covers the HA test suite.
+pytest-homeassistant-custom-component==0.13.316

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,25 @@
+# Tests
+
+Two layers:
+
+- **`test_offline.py`** — the HA-independent core (dataset parsing, value
+  typing, curated registry, binary-state decoding, login-field extraction).
+  Pure Python, no Home Assistant import. Runs anywhere:
+
+  ```bash
+  python tests/test_offline.py
+  ```
+
+- **`test_coordinator.py` / `test_config_flow.py`** — exercise the Home
+  Assistant integration (coordinator auth handling, multi-brand config/reauth
+  flow). These need the HA test harness:
+
+  ```bash
+  pip install -r requirements_test.txt
+  pytest tests/ -v
+  ```
+
+  The harness (`pytest-homeassistant-custom-component`) imports Unix-only
+  modules, so the `pytest` suite runs on **Linux/macOS or in CI**, not on
+  Windows. On Windows, run the offline suite above; the full suite runs in
+  GitHub Actions (`.github/workflows/test.yml`).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Shared pytest setup for the HA-dependent tests.
+
+Puts the repo root on the path so the integration imports under its real
+package name (``custom_components.vw_eu_data_act``) and loads the Home Assistant
+test harness.
+
+Note: the HA harness (pytest-homeassistant-custom-component) imports Unix-only
+modules, so ``pytest`` runs on Linux/macOS or in CI. On Windows, run the
+HA-independent suite directly: ``python tests/test_offline.py``.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+pytest_plugins = ["pytest_homeassistant_custom_component"]
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Allow HA to load the bundled custom integration during tests."""
+    yield

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,95 @@
+"""Config-flow tests: the reauth step must restore the entry's brand.
+
+A non-Volkswagen user (e.g. Škoda) who re-authenticates has to log in against
+their own brand's OIDC client. The reauth step therefore has to read CONF_BRAND
+back from the stored entry data; otherwise it falls back to the Volkswagen
+default and the login fails for everyone else.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.vw_eu_data_act.config_flow import EudaConfigFlow
+from custom_components.vw_eu_data_act.const import (
+    CONF_BRAND,
+    CONF_EMAIL,
+    CONF_IDENTIFIER,
+    CONF_PASSWORD,
+    CONF_VIN,
+    DEFAULT_BRAND,
+    DOMAIN,
+)
+
+CLIENT_PATH = "custom_components.vw_eu_data_act.config_flow.EudaApiClient"
+
+
+def _fake_client_capturing(captured: dict):
+    """A stand-in EudaApiClient that records the brand and logs in cleanly."""
+
+    class _FakeClient:
+        def __init__(self, session, email, password, brand=DEFAULT_BRAND) -> None:
+            captured["brand"] = brand
+
+        async def async_login(self) -> None:
+            return None
+
+        async def async_list_vehicles(self) -> list[dict]:
+            return [{"vin": "WVWZZZTESTVIN0001"}]
+
+    return _FakeClient
+
+
+async def test_reauth_restores_non_default_brand(hass) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_BRAND: "skoda",
+            CONF_EMAIL: "owner@example.com",
+            CONF_PASSWORD: "old-secret",
+            CONF_VIN: "WVWZZZTESTVIN0001",
+            CONF_IDENTIFIER: "ident-1",
+        },
+        unique_id="WVWZZZTESTVIN0001",
+    )
+    entry.add_to_hass(hass)
+
+    flow = EudaConfigFlow()
+    flow.hass = hass
+
+    result = await flow.async_step_reauth(dict(entry.data))
+    # The regression: brand restored from the entry, not left at the default.
+    assert flow._brand == "skoda"
+    assert result["type"] == "form"
+    assert result["step_id"] == "reauth_confirm"
+
+    captured: dict = {}
+    with patch(CLIENT_PATH, _fake_client_capturing(captured)):
+        assert await flow._async_try_login() is None
+    # ...and it is the brand handed to the API client.
+    assert captured["brand"] == "skoda"
+
+
+async def test_reauth_defaults_brand_when_absent(hass) -> None:
+    # Entries created before multi-brand support have no CONF_BRAND; they must
+    # default to Volkswagen for backward compatibility.
+    flow = EudaConfigFlow()
+    flow.hass = hass
+
+    await flow.async_step_reauth({CONF_EMAIL: "legacy@example.com"})
+    assert flow._brand == DEFAULT_BRAND
+
+
+async def test_user_step_selects_brand(hass) -> None:
+    # The first step offers a brand choice and advances to the credentials step.
+    flow = EudaConfigFlow()
+    flow.hass = hass
+
+    form = await flow.async_step_user(None)
+    assert form["type"] == "form"
+    assert form["step_id"] == "user"
+
+    nxt = await flow.async_step_user({CONF_BRAND: "audi"})
+    assert flow._brand == "audi"
+    assert nxt["step_id"] == "credentials"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,73 @@
+"""Coordinator tests: authentication failures surface as ConfigEntryAuthFailed.
+
+An expired/invalid login must trigger Home Assistant's reauth flow, not be
+swallowed as a transient polling error. AuthError is a subclass of ApiError, so
+the coordinator has to catch it *before* the generic ApiError handling in both
+the dataset-listing and dataset-download paths.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.vw_eu_data_act.api import ApiError, AuthError
+from custom_components.vw_eu_data_act.const import (
+    CONF_IDENTIFIER,
+    CONF_VIN,
+    DOMAIN,
+)
+from custom_components.vw_eu_data_act.coordinator import EudaCoordinator
+
+
+def _make_coordinator(hass, client) -> EudaCoordinator:
+    """Build a coordinator the way async_setup_entry does."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_VIN: "WVWZZZTESTVIN0001", CONF_IDENTIFIER: "ident-1"},
+        unique_id="WVWZZZTESTVIN0001",
+    )
+    entry.add_to_hass(hass)
+    return EudaCoordinator(hass, entry, client)
+
+
+async def test_auth_error_while_listing_raises_reauth(hass) -> None:
+    client = MagicMock()
+    client.async_list_datasets = AsyncMock(side_effect=AuthError("invalid token"))
+    coordinator = _make_coordinator(hass, client)
+
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coordinator._async_update_data()
+
+
+async def test_auth_error_while_downloading_raises_reauth(hass) -> None:
+    # Listing succeeds, but the download leg hits an expired session. Because
+    # AuthError subclasses ApiError, this previously fell into the retry/skip
+    # branch instead of triggering reauth.
+    client = MagicMock()
+    client.async_list_datasets = AsyncMock(
+        return_value=[
+            {"name": "WVWZZZTESTVIN0001_20260101000000.zip", "createdOn": "2026-01-01T00:00:00Z"}
+        ]
+    )
+    client.async_download_dataset = AsyncMock(side_effect=AuthError("session expired"))
+    coordinator = _make_coordinator(hass, client)
+
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coordinator._async_update_data()
+
+
+async def test_plain_api_error_does_not_raise_reauth(hass) -> None:
+    # A generic (non-auth) failure on first load must surface as a normal
+    # UpdateFailed, never as a reauth trigger. A 400 ("data delivery not ready")
+    # is not retried, so this stays fast and deterministic.
+    client = MagicMock()
+    client.async_list_datasets = AsyncMock(side_effect=ApiError("HTTP 400", status=400))
+    client.async_get_metadata = AsyncMock(side_effect=ApiError("no metadata", status=400))
+    coordinator = _make_coordinator(hass, client)
+
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -126,6 +126,37 @@ def main() -> int:
     _mintemp = next(s for s in data.CURATED_SENSORS_FLAT if s.field_name == "min_temperature")
     check("min_temperature named battery", _mintemp.name, "Battery min temperature")
 
+    # --- binary state decoding (encoding-driven, not field-name guessing) -
+    print("binary decode:")
+    dec = data.decode_binary_state
+    # plain booleans pass through; invert flips
+    check("bool true", dec(True, "open", False), True)
+    check("bool invert", dec(True, "open", True), False)
+    # "open": 2=active(on), 3=inactive(off), 0/1=unknown
+    check("open 2 -> on", dec(2, "open", False), True)
+    check("open 3 -> off", dec(3, "open", False), False)
+    check("open 0 -> unknown", dec(0, "open", False), None)
+    check("open 1 -> unknown", dec(1, "open", False), None)
+    # lock/safe reuse "open" with invert: 2=locked -> off, 3=unlocked -> on
+    check("lock 2 (locked) -> off", dec(2, "open", True), False)
+    check("lock 3 (unlocked) -> on", dec(3, "open", True), True)
+    # "onoff": parking_brake 0=off, 1=on
+    check("onoff 0 -> off", dec(0, "onoff", False), False)
+    check("onoff 1 -> on", dec(1, "onoff", False), True)
+    # "lights": 0/1=unknown, 2=off, 3/4/5=on
+    check("lights 1 -> unknown", dec(1, "lights", False), None)
+    check("lights 2 -> off", dec(2, "lights", False), False)
+    check("lights 4 -> on", dec(4, "lights", False), True)
+    # missing value stays unknown
+    check("none -> unknown", dec(None, "open", False), None)
+    # registry wires the special encodings to the right fields
+    _pbrake = next(b for b in data.CURATED_BINARY_FLAT if b.field_name == "parking_brake")
+    check("parking_brake encoding", _pbrake.encoding, "onoff")
+    _plights = next(b for b in data.CURATED_BINARY_FLAT if b.field_name == "parking_lights")
+    check("parking_lights encoding", _plights.encoding, "lights")
+    _door = next(b for b in data.CURATED_BINARY_FLAT if b.field_name == "open_state_tailgate")
+    check("door default encoding", _door.encoding, "open")
+
     # --- raw unique_id namespaced by VIN (multi-vehicle, issue #7) --------
     print("raw unique_id namespacing:")
     key = "1763a4fe-d8a6-3b8c-b095-70081f3e61c7"  # a key shared across vehicles

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -123,7 +123,7 @@ def main() -> int:
     print("curated registry:")
     check("soc is curated", "battery_state_report.soc" in data.CURATED_FIELDS, True)
     check("locked is curated", "locked" in data.CURATED_FIELDS, True)
-    _mintemp = next(s for s in data.CURATED_SENSORS if s.field_name == "min_temperature")
+    _mintemp = next(s for s in data.CURATED_SENSORS_FLAT if s.field_name == "min_temperature")
     check("min_temperature named battery", _mintemp.name, "Battery min temperature")
 
     # --- raw unique_id namespaced by VIN (multi-vehicle, issue #7) --------
@@ -184,7 +184,7 @@ def main() -> int:
     check("KM -> km", data.resolve_distance_unit("KM"), "km")
     check("lowercase miles -> mi", data.resolve_distance_unit("miles"), "mi")
     check("unknown -> None", data.resolve_distance_unit("LIGHTYEARS"), None)
-    mileage = next(s for s in data.CURATED_SENSORS if s.field_name == "mileage.value")
+    mileage = next(s for s in data.CURATED_SENSORS_DOTTED if s.field_name == "mileage.value")
     check("mileage declares unit_field", mileage.unit_field, "mileage.unit")
     # a miles dataset exposes mileage.unit so the sensor can pick "mi"
     ds_mi = data.Dataset.from_json({"vin": "V", "user_id": "u", "Data": [


### PR DESCRIPTION
Adds support for all VW Group brands and fixes a few authentication/robustness issues found along the way. Verified working against a live Škoda account.

## Multi-brand support

The integration now supports **Volkswagen · Audi · Škoda · SEAT · CUPRA**. Setup gains a brand-selection step; each brand uses its own OIDC `client_id` and `state` (client IDs sourced from the [evcc](https://github.com/evcc-io/evcc) project). Existing Volkswagen config entries keep working unchanged — everything defaults to `volkswagen` when `CONF_BRAND` is absent.

The multi-brand foundation and the German translation were originally contributed by **@TMA84** (commits preserved with original authorship in this branch).

## Bug fixes

- **Reauth restores the brand.** `async_step_reauth` now reads `CONF_BRAND` back from the entry, so a Škoda/Audi/SEAT/CUPRA user re-authenticates against their own brand instead of failing with Volkswagen credentials.
- **Auth failures trigger HA's reauth flow.** `AuthError` now raises `ConfigEntryAuthFailed` on **both** the dataset-listing and dataset-download paths. Since `AuthError` subclasses `ApiError`, the download path previously swallowed it as a transient error and never prompted reauth.
- **Forward-compat:** the coordinator passes `config_entry` explicitly to `DataUpdateCoordinator` — relying on the ContextVar is deprecated and breaks in HA 2026.8.

## Internal quality

- `ApiError` carries the originating HTTP `status`; the coordinator branches on it instead of substring-matching `"HTTP 500"` in the message.
- Binary state is decoded from an explicit per-sensor `encoding` (`open`/`onoff`/`lights`) rather than guessing from field-name substrings — now a pure, offline-tested function.
- The duplicated "smallest-UUID" field selection is consolidated into a single `data.find_by_field`; removed a dead `_apply_transform` method.

## Tests & CI

- New HA-harness tests cover the reauth-brand restore and the coordinator auth handling (`tests/test_coordinator.py`, `tests/test_config_flow.py`).
- Offline suite extended with binary-decode cases.
- GitHub Actions workflow runs the offline script + pytest on Linux. (The HA harness imports Unix-only modules, so the pytest suite runs in CI / on Linux-macOS; `tests/README.md` documents the Windows path.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)