### PR TITLE
Add entity that stores the date/time on which the car last generated the data package

### DIFF
--- a/custom_components/vw_eu_data_act/coordinator.py
+++ b/custom_components/vw_eu_data_act/coordinator.py
@@ -70,6 +70,7 @@ class EudaCoordinator(DataUpdateCoordinator[dict[str, DataPoint]]):
         self.vin: str = entry.data[CONF_VIN]
         self.identifier: str = entry.data[CONF_IDENTIFIER]
         self.latest_dataset: Dataset | None = None
+        self.captured_at: datetime | None = None
         self._is_initial_setup: bool = True
 
     async def _async_update_data(self) -> dict[str, DataPoint]:
@@ -178,6 +179,10 @@ class EudaCoordinator(DataUpdateCoordinator[dict[str, DataPoint]]):
             ) from last_error
 
         self._reschedule(listing)
+
+        # Track the latest captured_at timestamp
+        if self.captured_at is None: self.captured_at = self.latest_dataset.captured_at
+        else: self.captured_at = max(self.captured_at, self.latest_dataset.captured_at)
 
         # Merge new data with existing to preserve missing fields
         if self.data:

--- a/custom_components/vw_eu_data_act/data.py
+++ b/custom_components/vw_eu_data_act/data.py
@@ -507,7 +507,6 @@ CURATED_SENSORS_DOTTED: tuple[CuratedSensor, ...] = (
         None,
         None,
         icon="mdi:car-clock",
-        transform="timestamp",
     ),
     # === Enum/Status Sensors ===
     CuratedSensor(
@@ -953,7 +952,6 @@ CURATED_SENSORS_FLAT: tuple[CuratedSensor, ...] = (
         None,
         None,
         icon="mdi:car-clock",
-        transform="timestamp",
     ),
     # === Enum/Status Sensors ===
     CuratedSensor(

--- a/custom_components/vw_eu_data_act/data.py
+++ b/custom_components/vw_eu_data_act/data.py
@@ -500,6 +500,15 @@ CURATED_SENSORS_DOTTED: tuple[CuratedSensor, ...] = (
         None,
         icon="mdi:clock",
     ),
+    CuratedSensor(
+        "car_captured_time",
+        "Data captured",
+        "timestamp",
+        None,
+        None,
+        icon="mdi:car-clock",
+        transform="timestamp",
+    ),
     # === Enum/Status Sensors ===
     CuratedSensor(
         "charging_state_report.current_charge_state",
@@ -936,6 +945,15 @@ CURATED_SENSORS_FLAT: tuple[CuratedSensor, ...] = (
         None,
         None,
         icon="mdi:clock",
+    ),
+    CuratedSensor(
+        "car_captured_time",
+        "Data captured",
+        "timestamp",
+        None,
+        None,
+        icon="mdi:car-clock",
+        transform="timestamp",
     ),
     # === Enum/Status Sensors ===
     CuratedSensor(

--- a/custom_components/vw_eu_data_act/sensor.py
+++ b/custom_components/vw_eu_data_act/sensor.py
@@ -121,6 +121,11 @@ class EudaCuratedSensor(EudaEntity, SensorEntity):
 
     @property
     def native_value(self):
+        # car_captured_time appears in many report clusters; Dataset.from_json
+        # already picks the latest value as captured_at on the coordinator.
+        if self._curated.field_name == "car_captured_time":
+            return self._sticky(self.coordinator.captured_at)
+
         # Special handling for timestamp fields (both "mileage.timestamp" and "mileage.value.timestamp")
         if ".timestamp" in self._curated.field_name:
             base_field = self._curated.field_name.replace(".timestamp", "")

--- a/custom_components/vw_eu_data_act/sensor.py
+++ b/custom_components/vw_eu_data_act/sensor.py
@@ -138,6 +138,11 @@ class EudaCuratedSensor(EudaEntity, SensorEntity):
 
         # Apply transforms if specified
         if self._curated.transform:
+            if self._curated.transform == "timestamp":
+                from .data import _parse_timestamp
+
+                return self._sticky(_parse_timestamp(dp.raw_value))
+
             if self._curated.transform == "decikelvin_to_celsius":
                 from .data import decikelvin_to_celsius
 

--- a/custom_components/vw_eu_data_act/sensor.py
+++ b/custom_components/vw_eu_data_act/sensor.py
@@ -143,11 +143,6 @@ class EudaCuratedSensor(EudaEntity, SensorEntity):
 
         # Apply transforms if specified
         if self._curated.transform:
-            if self._curated.transform == "timestamp":
-                from .data import _parse_timestamp
-
-                return self._sticky(_parse_timestamp(dp.raw_value))
-
             if self._curated.transform == "decikelvin_to_celsius":
                 from .data import decikelvin_to_celsius
 

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -12,6 +12,7 @@ import json
 import sys
 import types
 import zipfile
+from datetime import datetime, timezone
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -102,6 +103,32 @@ def main() -> int:
     check("parking_brake", _field_val(ds, "parking_brake"), True)
     check("remaining_climate_time", _field_val(ds, "remaining_climate_time"), 0.0)
     check("captured_at present", ds.captured_at is not None, True)
+
+    # --- captured_at: latest across duplicate car_captured_time entries ---
+    print("captured_at max:")
+    ds_cap = data.Dataset.from_json(
+        {
+            "vin": "V",
+            "user_id": "u",
+            "Data": [
+                {
+                    "key": "old",
+                    "dataFieldName": "car_captured_time",
+                    "value": "2026-06-10T09:16:00+00:00",
+                },
+                {
+                    "key": "new",
+                    "dataFieldName": "car_captured_time",
+                    "value": "2026-06-17T09:52:47+00:00",
+                },
+            ],
+        }
+    )
+    check(
+        "captured_at is latest",
+        ds_cap.captured_at,
+        datetime(2026, 6, 17, 9, 52, 47, tzinfo=timezone.utc),
+    )
 
     # --- duplicate field: deterministic selection regardless of order -----
     print("duplicate field selection:")


### PR DESCRIPTION
This PR adds a new sensor entity that stores the date/time when the car last generated the data package. This data was already stored internally as `car_captured_time`, which is described as: "the timestamp when the ICAS1 (Java service in the car) has sent the report", i.e. when the vehicle generated the data. 

This PR exposes this timestamp as an entity. I suppose it's related to the "Last connected" entity, which I understand intends to expose when the EU data portal last received the data. However, that value never updated for my 2023 ID5.


Changes:
1. `data.py`: Added a `CuratedSensor("car_captured_time", ...)` to both `CURATED_SENSORS_DOTTED` and `CURATED_SENSORS_FLAT`.
2. `sensor.py` — Added a transform that runs the raw value through `_parse_timestamp`, returning a datetime. HA's timestamp device class requires a datetime, not the raw string, and `_parse_timestamp` already handles both ISO‑8601 and epoch‑millis encodings.

I've tested this and have confirmed this works for my 2023 ID5.