### PR TITLE
Curate additional flat-format sensors

### DIFF
--- a/custom_components/vw_eu_data_act/data.py
+++ b/custom_components/vw_eu_data_act/data.py
@@ -338,6 +338,20 @@ def abs_value(value) -> int | float | None:
         return None
 
 
+def strip_charging_time_sentinel(value) -> int | None:
+    """Map the uint16 "not charging" sentinel (65535) to unknown.
+
+    ``remaining_charging_time`` reports minutes while a charge is in progress,
+    but emits the uint16 max (65535) when nothing is charging. Surface that as
+    unknown rather than a bogus ~45-day duration.
+    """
+    try:
+        minutes = int(float(value))
+    except (ValueError, TypeError):
+        return None
+    return None if minutes >= 65535 else minutes
+
+
 def fuel_consumption_l_per_1000km_to_l_per_100km(value) -> float | None:
     """Convert fuel consumption from L/1000km to L/100km.
 
@@ -603,6 +617,27 @@ CURATED_BINARY_DOTTED: tuple[CuratedBinary, ...] = (
 # ---------------------------------------------------------------------------
 
 CURATED_SENSORS_FLAT: tuple[CuratedSensor, ...] = (
+    # === Charging & Battery ===
+    CuratedSensor("state_of_charge", "Battery", "battery", "%", "measurement"),
+    CuratedSensor("charging_state", "Charge state", icon="mdi:ev-station"),
+    CuratedSensor("charging_mode", "Charge mode", icon="mdi:ev-station"),
+    CuratedSensor("charging_reason_trigger", "Charge trigger", icon="mdi:ev-station"),
+    CuratedSensor("plug_state", "Plug state", icon="mdi:power-plug"),
+    CuratedSensor("energy_flow", "Energy flow", icon="mdi:transmission-tower"),
+    CuratedSensor(
+        "external_power_supply_state",
+        "External power supply",
+        icon="mdi:power-plug-outline",
+    ),
+    CuratedSensor(
+        "remaining_charging_time",
+        "Remaining charging time",
+        "duration",
+        "min",
+        "measurement",
+        icon="mdi:battery-clock",
+        transform="charging_time",
+    ),
     # === Distance & Range ===
     CuratedSensor(
         "mileage",
@@ -707,6 +742,15 @@ CURATED_SENSORS_FLAT: tuple[CuratedSensor, ...] = (
         "measurement",
         transform="duration_s",
     ),
+    # Some (pre-ID.x) vehicles report the remaining climate time under this
+    # alternate field name, already in minutes (vs. the "0s"-style duration above).
+    CuratedSensor(
+        "remaining_climatisation_time",
+        "Remaining climate time",
+        "duration",
+        "min",
+        "measurement",
+    ),
     CuratedSensor(
         "residual_energy_in_percent",
         "Residual energy",
@@ -751,6 +795,46 @@ CURATED_SENSORS_FLAT: tuple[CuratedSensor, ...] = (
     CuratedSensor(
         "tyre_pressure_actual_spare_tyre",
         "Tire pressure spare",
+        "pressure",
+        "bar",
+        "measurement",
+        icon="mdi:car-tire-alert",
+    ),
+    CuratedSensor(
+        "tyre_pressure_required_front_left",
+        "Tire pressure required FL",
+        "pressure",
+        "bar",
+        "measurement",
+        icon="mdi:car-tire-alert",
+    ),
+    CuratedSensor(
+        "tyre_pressure_required_front_right",
+        "Tire pressure required FR",
+        "pressure",
+        "bar",
+        "measurement",
+        icon="mdi:car-tire-alert",
+    ),
+    CuratedSensor(
+        "tyre_pressure_required_rear_left",
+        "Tire pressure required RL",
+        "pressure",
+        "bar",
+        "measurement",
+        icon="mdi:car-tire-alert",
+    ),
+    CuratedSensor(
+        "tyre_pressure_required_rear_right",
+        "Tire pressure required RR",
+        "pressure",
+        "bar",
+        "measurement",
+        icon="mdi:car-tire-alert",
+    ),
+    CuratedSensor(
+        "tyre_pressure_required_spare_tyre",
+        "Tire pressure required spare",
         "pressure",
         "bar",
         "measurement",
@@ -909,6 +993,17 @@ CURATED_SENSORS_FLAT: tuple[CuratedSensor, ...] = (
         suggested_display_precision=1,
     ),
     CuratedSensor(
+        "long_term_data_average_electr_engine_consumption",
+        "Avg electric consumption (long)",
+        None,
+        "kWh/100km",
+        "measurement",
+        icon="mdi:lightning-bolt",
+        # API reports kWh/1000km; the fuel transform's "/10" also yields per-100km.
+        transform="fuel_consumption",
+        suggested_display_precision=1,
+    ),
+    CuratedSensor(
         "long_term_data_average_speed",
         "Avg speed (long)",
         None,
@@ -954,6 +1049,17 @@ CURATED_SENSORS_FLAT: tuple[CuratedSensor, ...] = (
         suggested_display_precision=1,
     ),
     CuratedSensor(
+        "short_term_data_average_electr_engine_consumption",
+        "Avg electric consumption (short)",
+        None,
+        "kWh/100km",
+        "measurement",
+        icon="mdi:lightning-bolt",
+        # API reports kWh/1000km; the fuel transform's "/10" also yields per-100km.
+        transform="fuel_consumption",
+        suggested_display_precision=1,
+    ),
+    CuratedSensor(
         "short_term_data_travel_time",
         "Travel time (short)",
         "duration",
@@ -993,9 +1099,20 @@ CURATED_SENSORS_FLAT: tuple[CuratedSensor, ...] = (
         None,
         icon="mdi:clock",
     ),
+    CuratedSensor("lock_state", "Lock state", icon="mdi:lock"),
     # === Enum/Status Sensors ===
     CuratedSensor(
         "window_heating_state", "Window heating", icon="mdi:car-defrost-rear"
+    ),
+    CuratedSensor(
+        "window_heating_state_front",
+        "Window heating front",
+        icon="mdi:car-defrost-front",
+    ),
+    CuratedSensor(
+        "window_heating_state_rear",
+        "Window heating rear",
+        icon="mdi:car-defrost-rear",
     ),
     CuratedSensor("bem_level", "BEM level", None, None, None, icon="mdi:information"),
 )

--- a/custom_components/vw_eu_data_act/sensor.py
+++ b/custom_components/vw_eu_data_act/sensor.py
@@ -175,6 +175,12 @@ class EudaCuratedSensor(EudaEntity, SensorEntity):
                 transformed = fuel_consumption_l_per_1000km_to_l_per_100km(raw_value)
                 return self._sticky(transformed)
 
+            elif self._curated.transform == "charging_time":
+                from .data import strip_charging_time_sentinel
+
+                transformed = strip_charging_time_sentinel(raw_value)
+                return self._sticky(transformed)
+
         return self._sticky(_shorten_enum_value(dp, raw_value))
 
     @property

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -125,6 +125,13 @@ def main() -> int:
     check("locked is curated", "locked" in data.CURATED_FIELDS, True)
     _mintemp = next(s for s in data.CURATED_SENSORS_FLAT if s.field_name == "min_temperature")
     check("min_temperature named battery", _mintemp.name, "Battery min temperature")
+    # flat (eGolf-style) state_of_charge is curated as the Battery sensor
+    check("flat soc is curated", "state_of_charge" in data.CURATED_FIELDS, True)
+    _soc = next(s for s in data.CURATED_SENSORS_FLAT if s.field_name == "state_of_charge")
+    check("flat soc device_class", _soc.device_class, "battery")
+    # remaining_charging_time's uint16 sentinel reads as unknown, not ~45 days
+    check("charging-time sentinel -> None", data.strip_charging_time_sentinel(65535), None)
+    check("charging-time value kept", data.strip_charging_time_sentinel(120), 120)
 
     # --- binary state decoding (encoding-driven, not field-name guessing) -
     print("binary decode:")


### PR DESCRIPTION
Several useful data points in the flat dataset format were only exposed as disabled-by-default raw diagnostic sensors. This MR promotes them to proper curated sensors with correct device classes, units, and icons.

All additions are **pure data entries** in `CURATED_SENSORS_FLAT`, reusing the existing transform/enum/device-class machinery. The only logic change is a single transform branch in `sensor.py` (+ a small helper) to handle the charging-time sentinel.

### Sensors added

| Sensor | Field | Unit / Class | Notes |
|---|---|---|---|
| Battery | `state_of_charge` | % · `battery` | EV state of charge |
| Charge state | `charging_state` | enum text | |
| Charge mode | `charging_mode` | enum text | |
| Charge trigger | `charging_reason_trigger` | enum text | |
| Plug state | `plug_state` | enum text | |
| Energy flow | `energy_flow` | enum text | |
| External power supply | `external_power_supply_state` | enum text | |
| Remaining charging time | `remaining_charging_time` | min · `duration` | `65535` sentinel → unknown |
| Lock state | `lock_state` | enum text | |
| Remaining climate time | `remaining_climatisation_time` | min · `duration` | alternate field name, minutes |
| Window heating front | `window_heating_state_front` | enum text | |
| Window heating rear | `window_heating_state_rear` | enum text | |
| Avg electric consumption (short) | `short_term_data_average_electr_engine_consumption` | kWh/100km | reuses `/10` fuel transform |
| Avg electric consumption (long) | `long_term_data_average_electr_engine_consumption` | kWh/100km | reuses `/10` fuel transform |
| Tire pressure required FL | `tyre_pressure_required_front_left` | bar · `pressure` | mirrors `tyre_pressure_actual_*` |
| Tire pressure required FR | `tyre_pressure_required_front_right` | bar · `pressure` | |
| Tire pressure required RL | `tyre_pressure_required_rear_left` | bar · `pressure` | |
| Tire pressure required RR | `tyre_pressure_required_rear_right` | bar · `pressure` | |
| Tire pressure required spare | `tyre_pressure_required_spare_tyre` | bar · `pressure` | |

### Notes
- **`remaining_charging_time`**: reports the uint16 max (`65535`) when no charge is in progress; a new `strip_charging_time_sentinel()` transform maps it to *unknown* instead of a bogus
~45-day duration.
- **Electric consumption**: the API reports kWh/1000km; the existing fuel `/10` transform also yields per-100km, so it's reused (no new code).
- **Intentionally left as raw diagnostics**: `led_state`, `led_color`, `trueness`, `echo`, `window_heating_error_code`, `charging_state_error_code`,
`last_battery_charger_update_trigger`, `remaining_charging_time_target_soc`, and the gas/recuperation/aux/zero-emission/range-gain trip stats (low-value / niche / error codes).

### Tests
- Added offline assertions covering `state_of_charge` curation and the charging-time sentinel.