### PR TITLE
Expose source_dataset attribute on entities (#31)

### DIFF
--- a/custom_components/vw_eu_data_act/binary_sensor.py
+++ b/custom_components/vw_eu_data_act/binary_sensor.py
@@ -18,6 +18,7 @@ from .data import (
     DataPoint,
     decode_binary_state,
     detect_dataset_format,
+    entity_source_attributes,
     find_by_field,
 )
 from .entity import EudaEntity
@@ -66,3 +67,8 @@ class EudaBinarySensor(EudaEntity, BinarySensorEntity):
             value, self._curated.encoding, self._curated.invert
         )
         return self._sticky(result)
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        dp = find_by_field(self.coordinator.data or {}, self._curated.field_name)
+        return entity_source_attributes(dp)

--- a/custom_components/vw_eu_data_act/coordinator.py
+++ b/custom_components/vw_eu_data_act/coordinator.py
@@ -23,7 +23,7 @@ from .const import (
     POST_DATASET_BUFFER,
     RETRY_INTERVAL,
 )
-from .data import Dataset, DataPoint
+from .data import Dataset, DataPoint, stamp_source_dataset
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -82,6 +82,7 @@ class EudaCoordinator(DataUpdateCoordinator[dict[str, DataPoint]]):
         self.vin: str = entry.data[CONF_VIN]
         self.identifier: str = entry.data[CONF_IDENTIFIER]
         self.latest_dataset: Dataset | None = None
+        self.latest_dataset_name: str | None = None
         self._is_initial_setup: bool = True
 
     async def _async_update_data(self) -> dict[str, DataPoint]:
@@ -124,6 +125,7 @@ class EudaCoordinator(DataUpdateCoordinator[dict[str, DataPoint]]):
                         self.vin, self.identifier, dataset_entry["name"]
                     )
                     self.latest_dataset = Dataset.from_json(payload)
+                    self.latest_dataset_name = dataset_entry["name"]
                     self._is_initial_setup = False
                     last_error = None
                     break  # Success!
@@ -187,14 +189,18 @@ class EudaCoordinator(DataUpdateCoordinator[dict[str, DataPoint]]):
 
         self._reschedule(listing)
 
+        new_points = stamp_source_dataset(
+            self.latest_dataset.points, self.latest_dataset_name
+        )
+
         # Merge new data with existing to preserve missing fields
         if self.data:
             merged = dict(self.data)
-            merged.update(self.latest_dataset.points)
+            merged.update(new_points)
             return merged
 
         # First successful load
-        return self.latest_dataset.points
+        return new_points
 
     async def _async_list_with_refresh(self) -> list[dict]:
         """List datasets, self-healing a stale identifier once if needed.

--- a/custom_components/vw_eu_data_act/data.py
+++ b/custom_components/vw_eu_data_act/data.py
@@ -166,6 +166,8 @@ class DataPoint:
     description: str | None = None
     cluster: str | None = None
     timestamp_utc: str | None = None
+    # Portal ZIP filename that last supplied this point (issue #31).
+    source_dataset: str | None = None
 
     @property
     def value(self):
@@ -229,6 +231,24 @@ class Dataset:
     def by_field(self, field_name: str) -> DataPoint | None:
         """Return a single data point for a (possibly duplicated) field name."""
         return find_by_field(self.points, field_name)
+
+
+def stamp_source_dataset(
+    points: dict[str, DataPoint], dataset_name: str | None
+) -> dict[str, DataPoint]:
+    """Tag every point with the portal ZIP it came from."""
+    if not dataset_name:
+        return points
+    for dp in points.values():
+        dp.source_dataset = dataset_name
+    return points
+
+
+def entity_source_attributes(dp: DataPoint | None) -> dict[str, str]:
+    """Entity attributes exposing the portal ZIP that supplied a reading."""
+    if dp is None or not dp.source_dataset:
+        return {}
+    return {"source_dataset": dp.source_dataset}
 
 
 def find_by_field(

--- a/custom_components/vw_eu_data_act/sensor.py
+++ b/custom_components/vw_eu_data_act/sensor.py
@@ -25,6 +25,7 @@ from .data import (
     CuratedSensor,
     DataPoint,
     detect_dataset_format,
+    entity_source_attributes,
     find_by_field,
     friendly_name,
     resolve_distance_unit,
@@ -178,6 +179,14 @@ class EudaCuratedSensor(EudaEntity, SensorEntity):
         return self._sticky(_shorten_enum_value(dp, raw_value))
 
     @property
+    def extra_state_attributes(self) -> dict:
+        field_name = self._curated.field_name
+        if ".timestamp" in field_name:
+            field_name = field_name.replace(".timestamp", "")
+        dp = find_by_field(self.coordinator.data or {}, field_name)
+        return entity_source_attributes(dp)
+
+    @property
     def native_unit_of_measurement(self) -> str | None:
         # When a companion unit field is declared (e.g. mileage.unit), resolve
         # the unit at runtime so miles vs km is reported correctly per vehicle;
@@ -226,4 +235,5 @@ class EudaRawSensor(EudaEntity, SensorEntity):
             attrs["description"] = dp.description
         if dp.cluster:
             attrs["cluster"] = dp.cluster
+        attrs.update(entity_source_attributes(dp))
         return attrs

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -248,6 +248,19 @@ def main() -> int:
     dp_prose = data.DataPoint("k", "report_type", "3", "enum", None, "The enum value of report type")
     check("prose enum desc -> int kept", dp_prose.value, 3)
 
+    print("source_dataset:")
+    zip_name = "WVWZZZTESTVIN0001_20260102000000.zip"
+    stamped = data.stamp_source_dataset(
+        {"k": data.DataPoint(key="k", field_name="mileage", raw_value="100")},
+        zip_name,
+    )
+    check(
+        "entity_source_attributes",
+        data.entity_source_attributes(stamped["k"]).get("source_dataset"),
+        zip_name,
+    )
+    check("missing dataset name unchanged", data.stamp_source_dataset(stamped, None)["k"].source_dataset, zip_name)
+
     print()
     if failures:
         print(f"FAILED: {len(failures)} -> {failures}")


### PR DESCRIPTION
## Summary

Closes the remaining part of [mikrohard#31](https://github.com/mikrohard/hass-vw-eu-data-act/issues/31): each entity now exposes which portal ZIP supplied its current reading.

This is a minimal, self-contained change (~60 lines) — no local ZIP cache, no coordinator status sensor changes.

## Change

- `DataPoint.source_dataset` — stamped with the portal filename on each successful download
- **`source_dataset`** entity attribute on curated sensors, raw diagnostic sensors, and binary sensors
- Coordinator tracks `latest_dataset_name` and applies stamping before merge

Example attribute value: `20260620172612_VSSZZZK11SP000962.zip`

## Why

When users report oscillating values, wrong units, or stale data, support currently has to guess which snapshot HA used. The filename embeds the portal generation timestamp and makes issue reports actionable without asking users to manually correlate HA states with portal downloads.

Implemented and verified in our multi-brand fork ([TommiG1/HA_VAG-EU-Data-Act v0.6.24](https://github.com/TommiG1/HA_VAG-EU-Data-Act/releases/tag/v0.6.24)); ported here with upstream naming (`vw_eu_data_act`).

## Test plan

- [x] `python3 tests/test_offline.py` — `stamp_source_dataset` + `entity_source_attributes`
- [ ] Reload integration after update
- [ ] Developer tools → check any curated sensor for `source_dataset` attribute matching the latest downloaded ZIP