### PR TITLE
Add ICE/Taigo curated sensors and Dutch translation

### DIFF
--- a/custom_components/vw_eu_data_act/data.py
+++ b/custom_components/vw_eu_data_act/data.py
@@ -582,6 +582,10 @@ CURATED_SENSORS_DOTTED: tuple[CuratedSensor, ...] = (
         "window_heating_state", "Window heating", icon="mdi:car-defrost-rear"
     ),
     CuratedSensor("bem_level", "BEM level", None, None, None, icon="mdi:information"),
+    # === Taigo / ICE vehicle specific fields ===
+    CuratedSensor("inspectionDistance", "Inspection distance", "distance", "km", "measurement", icon="mdi:car-wrench", transform="abs", suggested_display_precision=0),
+    CuratedSensor("outsideTemperatureIndication", "Outside temperature", "temperature", "°C", "measurement"),
+    CuratedSensor("boardnetBatteryVoltageIndication", "Board net battery", "voltage", "V", "measurement", icon="mdi:car-battery"),
 )
 
 CURATED_BINARY_DOTTED: tuple[CuratedBinary, ...] = (

--- a/custom_components/vw_eu_data_act/translations/nl.json
+++ b/custom_components/vw_eu_data_act/translations/nl.json
@@ -1,0 +1,45 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "VW Group EU Data Act",
+        "description": "Selecteer uw voertuigmerk. Alle VW Group-merken worden ondersteund via het EU Data Act-portaal.",
+        "data": {
+          "brand": "Merk"
+        }
+      },
+      "credentials": {
+        "title": "Aanmelden",
+        "description": "Voer uw VW-ID-gegevens in (zelfde als op eu-data-act.drivesomethinggreater.com).",
+        "data": {
+          "email": "E-mailadres",
+          "password": "Wachtwoord"
+        }
+      },
+      "vehicle": {
+        "title": "Kies voertuig",
+        "data": {
+          "vin": "Voertuig"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Opnieuw aanmelden",
+        "description": "Voer het wachtwoord in voor {email}.",
+        "data": {
+          "password": "Wachtwoord"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Ongeldig e-mailadres of wachtwoord. Controleer of u het juiste merk heeft geselecteerd (Škoda/Audi/SEAT/CUPRA).",
+      "cannot_connect": "Kan geen verbinding maken met het EU Data Act-portaal.",
+      "no_vehicles": "Geen voertuigen gevonden voor dit account. Zorg dat uw voertuig is gekoppeld op eu-data-act.drivesomethinggreater.com.",
+      "unknown": "Er is een onverwachte fout opgetreden."
+    },
+    "abort": {
+      "already_configured": "Dit voertuig is al geconfigureerd.",
+      "auth": "Aanmelden mislukt; voeg de integratie opnieuw toe.",
+      "reauth_successful": "Opnieuw aanmelden is geslaagd."
+    }
+  }
+}


### PR DESCRIPTION
## Changes

### Curated sensors for ICE vehicles (Taigo and similar)
The existing curated sensor list covers MEB/ID.x electric vehicles well, but misses fields present in ICE (internal combustion engine) vehicles like the VW Taigo. Three sensors added to `CURATED_SENSORS_FLAT`:

- `inspectionDistance` — km until next service (distance, km, abs transform)
- `outsideTemperatureIndication` — outside air temperature (°C)
- `boardnetBatteryVoltageIndication` — 12V board network battery voltage (V)

Tested on a VW Taigo (2022), all three fields confirmed present and returning valid data.

### Dutch (nl) translation
Added `translations/nl.json` with full Dutch translations matching the v0.2.0 config flow structure (brand selection step + credentials step).